### PR TITLE
Add a unit test to ChartHelper.serie_to_df

### DIFF
--- a/degiro_connector/quotecast/actions/action_get_chart.py
+++ b/degiro_connector/quotecast/actions/action_get_chart.py
@@ -1,12 +1,12 @@
 # IMPORTATION STANDARD
-import requests
 import logging
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Optional
 
 # IMPORTATION THIRD PARTY
 import orjson as json
 import pandas as pd
+import requests
 from google.protobuf import json_format
 from google.protobuf.message import Message
 
@@ -194,7 +194,7 @@ class ChartHelper:
         else:
             raise AttributeError(f"Unknown serie, serie.type = {serie.type}")
 
-        return pd.DataFrame(serie.data, columns=columns)
+        return pd.DataFrame.from_records(serie.data, columns=columns)
 
 
 class ActionGetChart(AbstractAction):

--- a/tests/degiro_connector/quotecast/conftest.py
+++ b/tests/degiro_connector/quotecast/conftest.py
@@ -7,6 +7,7 @@ import urllib3
 
 # IMPORTATION INTERNAL
 from degiro_connector.quotecast.api import API as QuotecastAPI
+from degiro_connector.quotecast.models.quotecast_pb2 import Chart
 
 # SETUP LOGGING
 logging.basicConfig(level=logging.FATAL)
@@ -27,3 +28,21 @@ def quotecast_connected(quotecast) -> QuotecastAPI:
     quotecast.connect()
 
     return quotecast
+
+
+@pytest.mark.quotecast
+@pytest.fixture(scope="module")
+def stock_request() -> Chart.Request:
+    request = Chart.Request()
+
+    request.requestid = "1"
+    request.resolution = Chart.Interval.PT1M
+    request.culture = "fr-FR"
+    request.series.append("issueid:360148977")
+    request.series.append("price:issueid:360148977")
+    request.series.append("ohlc:issueid:360148977")
+    request.series.append("volume:issueid:360148977")
+    request.period = Chart.Interval.P1D
+    request.tz = "Europe/Paris"
+
+    return request

--- a/tests/degiro_connector/quotecast/test_quotecast_network.py
+++ b/tests/degiro_connector/quotecast/test_quotecast_network.py
@@ -4,13 +4,15 @@ import random
 import time
 
 # IMPORTATION THIRD PARTY
+import pandas
 import pytest
 import urllib3
 
 # IMPORTATION INTERNAL
 import degiro_connector.core.helpers.pb_handler as pb_handler
+from degiro_connector.quotecast.actions.action_get_chart import ChartHelper
 from degiro_connector.quotecast.models.quotecast_parser import QuotecastParser
-from degiro_connector.quotecast.models.quotecast_pb2 import Chart, Quotecast
+from degiro_connector.quotecast.models.quotecast_pb2 import Quotecast
 
 # SETUP LOGGING
 logging.basicConfig(level=logging.FATAL)
@@ -20,23 +22,12 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # TESTS FEATURES
 @pytest.mark.network
 @pytest.mark.quotecast
-def test_chart(quotecast_connected):
+def test_chart(quotecast_connected, stock_request):
     time.sleep(random.uniform(0, 2))
-
-    request = Chart.Request()
-    request.requestid = "1"
-    request.resolution = Chart.Interval.PT1M
-    request.culture = "fr-FR"
-    request.series.append("issueid:360148977")
-    request.series.append("price:issueid:360148977")
-    request.series.append("ohlc:issueid:360148977")
-    request.series.append("volume:issueid:360148977")
-    request.period = Chart.Interval.P1D
-    request.tz = "Europe/Paris"
 
     # FETCH DATA
     chart = quotecast_connected.get_chart(
-        request=request,
+        request=stock_request,
         raw=True,
     )
 
@@ -93,6 +84,24 @@ def test_chart(quotecast_connected):
     assert chart["resolution"] == "PT1M"
     assert chart["series"][0]["data"]["quality"] == "REALTIME"
     assert chart["series"][0]["data"]["issueId"] == 360148977
+
+
+@pytest.mark.quotecast
+@pytest.mark.network
+def test_format_chart(quotecast_connected, stock_request):
+    time.sleep(random.uniform(0, 2))
+
+    # FETCH DATA
+    chart = quotecast_connected.get_chart(
+        request=stock_request,
+        raw=False,
+    )
+
+    ChartHelper.format_chart(chart=chart, copy=False)
+    chart0_df = ChartHelper.serie_to_df(serie=chart.series[1])
+
+    assert isinstance(chart0_df, pandas.DataFrame)
+    assert len(chart0_df) > 0
 
 
 @pytest.mark.quotecast

--- a/tests/degiro_connector/quotecast/test_quotecast_network.py
+++ b/tests/degiro_connector/quotecast/test_quotecast_network.py
@@ -98,10 +98,14 @@ def test_format_chart(quotecast_connected, stock_request):
     )
 
     ChartHelper.format_chart(chart=chart, copy=False)
-    chart0_df = ChartHelper.serie_to_df(serie=chart.series[1])
+    chart1 = chart.series[1]
+    chart1_df = ChartHelper.serie_to_df(serie=chart1)
 
-    assert isinstance(chart0_df, pandas.DataFrame)
-    assert len(chart0_df) > 0
+    assert isinstance(chart1_df, pandas.DataFrame)
+    assert len(chart1_df) == len(chart1.data)
+
+    for index, row in chart1_df.iterrows():
+        assert row.price == chart1.data[index][1]
 
 
 @pytest.mark.quotecast


### PR DESCRIPTION
`pandas` 1.3.x made breaking changes on their DataFrame constructor which made the `serie_to_df` method raise exceptions when this library started supporting the latest `pandas` versions.

This issue was already fixed in this repository on https://github.com/Chavithra/degiro-connector/commit/312c18fd14bb54ca675d7eb60e2dfd2a65c5891e, but I have a PR adding a simple unit test on this method.

Also, the latest `pandas` versions require Python `>= 3.7.1`, so I had to change the poetry dependencies here in order to bump the `pandas` version.

Follow up from: https://github.com/Chavithra/degiro-connector/issues/29