### PR TITLE
Improve documentation for section 4 Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ Creating and updating of orders is done with an `Order` object. Here are the par
 
 |**Parameter**|**Type**|**Description**|
 |:-|:-|:-|
-|id|str|Optional for [`update_order()`](#42-how-to-update-an-order-) and [`delete_order()`](#43-how-to-delete-an-order-). It's the `order_id` of the created `Order` as returned by [`confirm_order()`](#412-confirm-order).|
+|id|str|Optional for [`update_order()`](#42-how-to-update-an-order-). It's the `order_id` of the created `Order` as returned by [`confirm_order()`](#412-confirm-order).|
 |action|`Order.Action`|Whether you want to : `BUY` or `SELL`.|
 |order_type|`Order.OrderType`|Type of order : `LIMIT`, `STOP_LIMIT`, `MARKET` or `STOP_LOSS`.|
 |price|float|Limit price of the order. <br /> Optional for the following `order_type` : `LIMIT` and `STOPLIMIT`.|

--- a/README.md
+++ b/README.md
@@ -782,11 +782,10 @@ On a succesfull request, a `dict` with the following parameters is returned:
 |**Parameter**|**Type**|**Description**|
 |:-|:-|:-|
 |confirmation_id|str|Id necessary to confirm the creation of the Order by the [`confirm_order()`](#412-confirm-order) function.|
-|free_space_new|float|New free space (balance) if the Order is confirmed.|
 |response_datetime|[`Timestamp`](https://pythonhosted.org/gax-google-pubsub-v1/google.protobuf.timestamp_pb2.html)|A `Timestamp` represents a point in time independent of any time zone or calendar, represented as seconds (`seconds`) and fractions of seconds at nanosecond resolution (`nanos`) in UTC Epoch time. A `Timestamp` can be converted to a RFC 3339 date string by using `ToJsonString()`.<br> Note: This `Timestamp` is created by Degiro Connector on reception of the API response, not by DeGiro server.|
-|transaction_fees|repeated Struct|Transaction fees that will be applied to the Order.|
-|transaction_opposite_fees|repeated Struct|Other kind of fees that will be applied to the Order.|
-|transaction_taxes|repeated Struct|Taxes that will be applied to the Order.|
+|free_space_new|float|New free space (balance) if the Order is confirmed.|
+|transaction_fees|float|Transaction fees that will be applied to the Order.|
+|show_ex_ante_report_link|bool|?|
 
 When the request fails, `None` is returned.
 

--- a/README.md
+++ b/README.md
@@ -841,14 +841,25 @@ For a more comprehensive example :
 
 ## 4.2. How to update an Order ?
 
-To modify a specific Order you need to setup it's "id".
+To modify a specific Order, you need to set it up with the `order_id` from the [`confirm_order()`](#412-confirm-order) response and use the `update_order()` function of the Trading API:
 
-Here is an example :
+### **Request parameters**
+
+|**Parameter**|**Type**|**Description**|
+|:-|:-|:-|
+|order|`Order`|The order to update with all necessary [parameters](#4-order), including `id` as returned by [`confirm_order()`](#412-confirm-order).|
+
+### **Response parameters**
+On a succesfull request, a `bool` with the value `True` is returned.
+
+When the request fails, `None` is returned. A valid reason is that the pending order has been already executed on the exchange, and this `order_id` no longer exists.
+
+Here is an example:
 
 ```python
 # ORDER SETUP
 order = Order(
-    id=YOUR_ORDER_ID,
+    id=YOUR_ORDER_ID,   # `order_id` from `confirm_order()` response
     action=Order.Action.BUY,
     order_type=Order.OrderType.LIMIT,
     price=10.60,
@@ -863,13 +874,24 @@ succcess = trading_api.update_order(order=order)
 
 ## 4.3. How to delete an Order ?
 
-To delete a specific Order you just need it's "id".
+To delete a specific Order you just need the `order_id` from the [`confirm_order()`](#412-confirm-order) response and use the `delete_order()` function of the Trading API:
 
-Here is an example :
+### **Request parameters**
+
+|**Parameter**|**Type**|**Description**|
+|:-|:-|:-|
+|order_id|str|The unique id of the accepted order as returned by [`confirm_order()`](#412-confirm-order).|
+
+### **Response parameters**
+On a succesfull request, a `bool` with the value `True` is returned.
+
+When the request fails, `None` is returned. A valid reason is that the pending order has been already executed on the exchange, and this `order_id` no longer exists.
+
+Here is an example:
 
 ```python
 # DELETE ORDER
-succcess = trading_api.delete_order(order_id=YOUR_ORDER_ID)
+succcess = trading_api.delete_order(order_id=YOUR_ORDER_ID) # `order_id` from `confirm_order()` response
 ```
 
 # 5. Portfolio


### PR DESCRIPTION
* Added subsections to 4.1 for Check and Confirm
* For each of the 4 order related function calls:
   * Added request and response type and parameters
   * Added erroneous response
* Explained the Google `Timestamp` incl. a link and note
* Brought 4.1.1 in line with latest 2.0.14 release; however, used existing Pythonian parameter names as an update of the connector is expected (see: https://github.com/Chavithra/degiro-connector/issues/56#issuecomment-1015534662 )