### PR TITLE
return_type for a map_element method declared explicity

### DIFF
--- a/degiro_connector/quotecast/tools/ticker_to_df.py
+++ b/degiro_connector/quotecast/tools/ticker_to_df.py
@@ -104,7 +104,7 @@ class TickerToDF:
     def ticker_to_metric_list(self) -> TickerToMetricList:
         return self.__ticker_to_metric_list
 
-        def add_request_duration_column(
+    def add_request_duration_column(
         self,
         df: pl.DataFrame,
         last_metric_list: list[Metric],
@@ -155,6 +155,7 @@ class TickerToDF:
         df = df.drop("response_datetime")
 
         return df
+    
     def parse(self, ticker: Ticker) -> pl.DataFrame | None:
         stored_metric_list = self.__stored_metric_list
         ticker_to_metric_list = self.__ticker_to_metric_list

--- a/degiro_connector/quotecast/tools/ticker_to_df.py
+++ b/degiro_connector/quotecast/tools/ticker_to_df.py
@@ -104,7 +104,7 @@ class TickerToDF:
     def ticker_to_metric_list(self) -> TickerToMetricList:
         return self.__ticker_to_metric_list
 
-    def add_request_duration_column(
+        def add_request_duration_column(
         self,
         df: pl.DataFrame,
         last_metric_list: list[Metric],
@@ -118,7 +118,8 @@ class TickerToDF:
 
         df = df.with_columns(
             request_duration_s=pl.col("product_id")
-            .map_elements(lambda x: self.__stored_request_duration_map.get(x, None))
+            .map_elements(lambda x: self.__stored_request_duration_map.get(x, None),
+                          return_dtype=pl.Float64) # this prevents map_elements to throw MapWithoutReturnDtypeWarning
             .cast(pl.Float64)
         )
 
@@ -137,7 +138,8 @@ class TickerToDF:
 
         df = df.with_columns(
             response_datetime=pl.col("product_id").map_elements(
-                lambda x: self.__stored_response_datetime_map.get(x, None)
+                lambda x: self.__stored_response_datetime_map.get(x, None),
+                return_dtype=pl.Datetime # this prevents map_elements to throw MapWithoutReturnDtypeWarning
             )
         )
         df = df.with_columns(
@@ -153,7 +155,6 @@ class TickerToDF:
         df = df.drop("response_datetime")
 
         return df
-
     def parse(self, ticker: Ticker) -> pl.DataFrame | None:
         stored_metric_list = self.__stored_metric_list
         ticker_to_metric_list = self.__ticker_to_metric_list

--- a/degiro_connector/quotecast/tools/ticker_to_df.py
+++ b/degiro_connector/quotecast/tools/ticker_to_df.py
@@ -155,7 +155,7 @@ class TickerToDF:
         df = df.drop("response_datetime")
 
         return df
-    
+
     def parse(self, ticker: Ticker) -> pl.DataFrame | None:
         stored_metric_list = self.__stored_metric_list
         ticker_to_metric_list = self.__ticker_to_metric_list


### PR DESCRIPTION
as per today's discussion ([link](https://github.com/Chavithra/degiro-connector/issues/140#issue-2292365206)).
This is a pull request with both modification needed to remove the warnings.

return type for a map_element method declared explicity and hardcoded to avoid MapWithoutReturnDtypeWarning in ticker_to_df.py, two formatting methods of the TicketToDF class.

I used three commits because the first time around few more things were changed in the code (indentation and new lines). I preferred to make a pull request with minimal change to the code. Hope that it is not creating confusion

