### PR TITLE
Improved Login Errors

### DIFF
--- a/degiro_connector/core/exceptions.py
+++ b/degiro_connector/core/exceptions.py
@@ -1,0 +1,12 @@
+class DeGiroConnectionError(ConnectionError):
+    """Exception raised for data validation errors."""
+    def __init__(self, message, error_details):
+        """
+        Initializes the exception with a message and a structure of error details.
+
+        Args:
+            message (str): The error message.
+            error_details (LoginError): The login error details
+        """
+        super().__init__(message)
+        self.error_details = error_details

--- a/degiro_connector/trading/actions/action_connect.py
+++ b/degiro_connector/trading/actions/action_connect.py
@@ -1,5 +1,6 @@
 import logging
 
+from degiro_connector.core.exceptions import DeGiroConnectionError
 import onetimepass as otp
 import requests
 
@@ -104,10 +105,10 @@ class ActionConnect(AbstractAction):
             )
 
         if login_error and login_error.status == 6:
-            raise ConnectionError('2FA is enabled, please provide the "totp_secret".')
+            raise DeGiroConnectionError('2FA is enabled, please provide the "totp_secret".', login_error)
 
         if login_sucess is None:
-            raise ConnectionError("No session id returned.")
+            raise DeGiroConnectionError("No session id returned.", login_error)
 
         logger.info(
             "login_sucess: %s",

--- a/examples/trading/connection.py
+++ b/examples/trading/connection.py
@@ -1,5 +1,6 @@
 import logging
 
+from degiro_connector.core.exceptions import DeGiroConnectionError
 from degiro_connector.trading.api import API as TradingAPI
 from degiro_connector.trading.models.credentials import build_credentials
 
@@ -15,9 +16,16 @@ credentials = build_credentials(
     # },
 )
 trading_api = TradingAPI(credentials=credentials)
-trading_api.connect()
+try:
+    trading_api.connect()
+except DeGiroConnectionError as degiro_error:
+    print(f"Error loging to Degiro: {degiro_error}")
+    if degiro_error.error_details:
+        print(degiro_error.error_details)
+except ConnectionError as connection_error:
+    print(f"ConnectionError: {connection_error}")
+else:
+    # ACCESS SESSION_ID
+    session_id = trading_api.connection_storage.session_id
 
-# ACCESS SESSION_ID
-session_id = trading_api.connection_storage.session_id
-
-print("You are now connected, with the session id :", session_id)
+    print("You are now connected, with the session id :", session_id)


### PR DESCRIPTION
When login to DeGiro, the current code doesn't provide enough information to understand the error type.

The new `DeGiroConnectionError` extends the default `ConnectionError`, so any existing code will still catch the error. But now, we can also access the `LoginError` details.

That means that once we catch the error, we can easily check the `error_details` structure and identify if it's a 'badCredentials' error or something else. If there's no `error_details` structure we can only guess, but could be an HTTPError. The code can be improved further to properly identify other cases.