### PR TITLE
Fix ticker_to_df.py: Some stock symbols provide a LastDate but no Las…

### DIFF
--- a/degiro_connector/quotecast/tools/ticker_to_df.py
+++ b/degiro_connector/quotecast/tools/ticker_to_df.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import polars as pl
+from datetime import time
 
 from degiro_connector.quotecast.models.metric import Metric
 from degiro_connector.quotecast.models.ticker import Ticker
@@ -47,6 +48,13 @@ class TickerToDF:
         order_column_list = list(
             filter(lambda column: column.endswith("Orders"), df.columns)
         )
+
+        # Some stock symbols provide a LastDate but no LastTime
+        if "LastTime" not in df.columns:
+            # Create midnight time value (00:00:00)
+            midnight_time = time(0, 0, 0)  # midnight time
+            # Add 'LastTime' column with midnight UTC as the default value
+            df = df.with_columns((pl.lit(midnight_time)).alias("LastTime"))
 
         df = df.with_columns(
             (pl.col("LastDate") + " " + pl.col("LastTime")).alias("LastDatetime")

--- a/degiro_connector/quotecast/tools/ticker_to_df.py
+++ b/degiro_connector/quotecast/tools/ticker_to_df.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 
 import polars as pl
-from datetime import time
 
 from degiro_connector.quotecast.models.metric import Metric
 from degiro_connector.quotecast.models.ticker import Ticker
@@ -49,12 +48,8 @@ class TickerToDF:
             filter(lambda column: column.endswith("Orders"), df.columns)
         )
 
-        # Some stock symbols provide a LastDate but no LastTime
         if "LastTime" not in df.columns:
-            # Create midnight time value (00:00:00)
-            midnight_time = time(0, 0, 0)  # midnight time
-            # Add 'LastTime' column with midnight UTC as the default value
-            df = df.with_columns((pl.lit(midnight_time)).alias("LastTime"))
+            df = df.with_columns((pl.lit("00:00:00")).alias("LastTime"))
 
         df = df.with_columns(
             (pl.col("LastDate") + " " + pl.col("LastTime")).alias("LastDatetime")


### PR DESCRIPTION
If the value for LastTime is missing in a stock symbol, TickerToDF.parse() will crash.
This fix prevents that by adding the missing column and filling it with midnight time (00:00:00).

See #157 for details.

Attention:
I am a Python noob guided by ChatGTP and StackOverflow. Please review carefully.