### PR TITLE
Improved Scheduled Maintenance

### DIFF
--- a/degiro_connector/core/exceptions.py
+++ b/degiro_connector/core/exceptions.py
@@ -10,3 +10,16 @@ class DeGiroConnectionError(ConnectionError):
         """
         super().__init__(message)
         self.error_details = error_details
+
+class MaintenanceError(DeGiroConnectionError):
+    """Exception raised when DeGiro is in maintenance mode."""
+    def __init__(self, message, error_details):
+        """
+        Initializes the exception with a message and a structure of error details.
+
+        Args:
+            message (str): The error message.
+            error_details (LoginError): The login error details
+        """
+        super().__init__(message)
+        self.error_details = error_details

--- a/degiro_connector/trading/actions/action_connect.py
+++ b/degiro_connector/trading/actions/action_connect.py
@@ -1,6 +1,6 @@
 import logging
 
-from degiro_connector.core.exceptions import DeGiroConnectionError
+from degiro_connector.core.exceptions import DeGiroConnectionError, MaintenanceError
 from html.parser import HTMLParser
 import onetimepass as otp
 import requests
@@ -111,7 +111,7 @@ class ActionConnect(AbstractAction):
             raise DeGiroConnectionError('2FA is enabled, please provide the "totp_secret".', login_error)
 
         if login_error and login_error.status == 405:
-            raise DeGiroConnectionError('Scheduled Maintenance.', login_error)
+            raise MaintenanceError('Scheduled Maintenance.', login_error)
 
         if login_sucess is None:
             raise DeGiroConnectionError("No session id returned.", login_error)


### PR DESCRIPTION
Follow up for https://github.com/Chavithra/degiro-connector/pull/174

A new `MaintenanceError` exception is defined.

I see 2 options, either `MaintenanceError` extends from `DeGiroConnectionError` and we "make up" the status error (`405` is the http status and not a DeGiro code) or it extends from a more generic exception like `ConnectionError` and no 'error_details' are added.

I've no preference. What do you think?