### PR TITLE
Migrated to Pydantic v2

### DIFF
--- a/degiro_connector/trading/models/account.py
+++ b/degiro_connector/trading/models/account.py
@@ -1,7 +1,7 @@
 from datetime import datetime, date
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 from pydantic.alias_generators import to_camel
 
 
@@ -9,11 +9,14 @@ class OverviewRequest(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True,
-        json_encoders={date: lambda v: v.strftime("%d/%m/%Y") if v else None},
     )
 
     from_date: date
     to_date: date
+
+    @field_serializer("from_date", "to_date")
+    def serialize_date(self, v: date | None) -> str | None:
+        return v.strftime("%d/%m/%Y") if v else None
 
 
 class CashMovements(BaseModel):
@@ -56,7 +59,6 @@ class ReportRequest(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True,
-        json_encoders={date: lambda v: v.strftime("%d/%m/%Y") if v else None},
     )
 
     country: str
@@ -67,6 +69,10 @@ class ReportRequest(BaseModel):
 
     int_account: int | None = Field(default=None)
     session_id: str | None = Field(default=None)
+
+    @field_serializer("from_date", "to_date")
+    def serialize_date(self, v: date | None) -> str | None:
+        return v.strftime("%d/%m/%Y") if v else None
 
 
 class Report(BaseModel):

--- a/degiro_connector/trading/models/agenda.py
+++ b/degiro_connector/trading/models/agenda.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 from pydantic.alias_generators import to_camel
 
 
@@ -19,9 +19,6 @@ class AgendaRequest(BaseModel):
         alias_generator=to_camel,
         extra="allow",
         populate_by_name=True,
-        json_encoders={
-            datetime: lambda v: v.strftime("%Y-%m-%dT%H:%M:%SZ") if v else None
-        },
     )
 
     calendar_type: CalendarType
@@ -38,6 +35,10 @@ class AgendaRequest(BaseModel):
 
     int_account: int | None = Field(default=None)
     session_id: str | None = Field(default=None)
+
+    @field_serializer("start_date", "end_date")
+    def serialize_datetime(self, v: datetime | None) -> str | None:
+        return v.strftime("%Y-%m-%dT%H:%M:%SZ") if v else None
 
 
 class Agenda(BaseModel):

--- a/degiro_connector/trading/models/credentials.py
+++ b/degiro_connector/trading/models/credentials.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 
 from orjson import loads
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 
 class Credentials(BaseModel):
@@ -12,11 +12,10 @@ class Credentials(BaseModel):
     totp_secret_key: str | None = Field(default=None)
     one_time_password: int | None = Field(default=None)
 
-    @validator("totp_secret_key")
+    @field_validator("totp_secret_key")
     @classmethod
-    def one_of(cls, v, values, **kwargs):
-        _ = kwargs
-        if "one_time_password" in values and values["one_time_password"] is not None:
+    def one_of(cls, v: int, info: ValidationInfo):
+        if "one_time_password" in info.data and info.data["one_time_password"] is not None:
             raise ValueError(
                 "You can't set both `one_time_password` and `totp_secret_key`."
             )

--- a/degiro_connector/trading/models/order.py
+++ b/degiro_connector/trading/models/order.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 from pydantic.alias_generators import to_camel
 
 
@@ -178,7 +178,6 @@ class HistoryRequest(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True,
-        json_encoders={date: lambda v: v.strftime("%d/%m/%Y") if v else None},
     )
 
     from_date: date
@@ -186,3 +185,7 @@ class HistoryRequest(BaseModel):
 
     int_account: int | None = Field(default=None)
     session_id: str | None = Field(default=None)
+
+    @field_serializer("from_date", "to_date")
+    def serialize_date(self, v: date | None) -> str | None:
+        return v.strftime("%d/%m/%Y") if v else None

--- a/degiro_connector/trading/models/transaction.py
+++ b/degiro_connector/trading/models/transaction.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 from pydantic.alias_generators import to_camel
 
 
@@ -8,7 +8,6 @@ class HistoryRequest(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True,
-        json_encoders={date: lambda v: v.strftime("%d/%m/%Y") if v else None},
     )
 
     from_date: date
@@ -17,6 +16,10 @@ class HistoryRequest(BaseModel):
 
     int_account: int | None = Field(default=None)
     session_id: str | None = Field(default=None)
+
+    @field_serializer("from_date", "to_date")
+    def serialize_date(self, v: date | None) -> str | None:
+        return v.strftime("%d/%m/%Y") if v else None
 
 
 class HistoryItem(BaseModel):


### PR DESCRIPTION
Degiro Connector was already using Pydantic v2, but some of the code was identified as deprecated and showing some warnings.

Following the documentation at https://docs.pydantic.dev/2.11/migration/ this PR replaces the deprecated code by the 'new' Pydantic v2 implementations.

I executed different tests and everything seems to keep working as expected