### PR TITLE
Replace the OTP dependency

### DIFF
--- a/degiro_connector/trading/actions/action_connect.py
+++ b/degiro_connector/trading/actions/action_connect.py
@@ -2,7 +2,7 @@ import logging
 
 from degiro_connector.core.exceptions import DeGiroConnectionError
 from html.parser import HTMLParser
-import onetimepass as otp
+import pyotp
 import requests
 
 from degiro_connector.core.constants import urls
@@ -58,7 +58,7 @@ class ActionConnect(AbstractAction):
                 one_time_password = str(credentials.one_time_password)
             else:
                 totp_secret_key = credentials.totp_secret_key
-                one_time_password = str(otp.get_totp(totp_secret_key))
+                one_time_password = str(pyotp.TOTP(totp_secret_key).now())
         else:
             url = urls.LOGIN
             one_time_password = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ version = "3.0.28"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-onetimepass = "^1.0.1"
+pyotp = "^2.9.0"
 requests = "^2.31.0"
 pydantic = "^2.0.3"
 polars = "^0.20.2"


### PR DESCRIPTION
The `onetimepass` dependency hasn't been upgraded in more than 10 years and has barely no users.

This PR replaces it by `pyotp` which has more than 3K stars.

More information can be found at https://pyauth.github.io/pyotp/