### PR TITLE
Fixed MaintenanceError exception

### DIFF
--- a/degiro_connector/core/exceptions.py
+++ b/degiro_connector/core/exceptions.py
@@ -21,5 +21,4 @@ class MaintenanceError(DeGiroConnectionError):
             message (str): The error message.
             error_details (LoginError): The login error details
         """
-        super().__init__(message)
-        self.error_details = error_details
+        super().__init__(message, error_details)


### PR DESCRIPTION
The `MaintenanceError` inherits `DeGiroConnectionError`, but the constructor was not properly passing the `error_details`

This was overseen in https://github.com/Chavithra/degiro-connector/pull/177