### PR TITLE
feat: Added support to filter by ISIN when retrieving the Agenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -2059,6 +2059,7 @@ Here are the available parameters for `Agenda.Request` :
 |order_by_desc|bool|-|
 |start_date|Timestamp|Events starting after this date.|
 |end_date|Timestamp|Events before this date.|
+|isin|str| Filter by the company ISIN.|
 |company_name|str|Filter used on the events description.|
 |countries|str|Comma separated list of countries like : `FR,US`|
 |classifications|str|Comma separated list of sectors like : `GovernmentSector,ExternalSector`|

--- a/src/degiro_connector/trading/models/agenda.py
+++ b/src/degiro_connector/trading/models/agenda.py
@@ -32,6 +32,7 @@ class AgendaRequest(BaseModel):
     sort_type: str | None = Field(default="asc")
     start_date: datetime
     units: str | None = Field(default=None)
+    isin: str | None = Field(default=None)
 
     int_account: int | None = Field(default=None)
     session_id: str | None = Field(default=None)


### PR DESCRIPTION
While retrieving the agenda events, it's also possible to filter by ISIN