### PR TITLE
Update product_search.py

### DIFF
--- a/src/degiro_connector/trading/models/product_search.py
+++ b/src/degiro_connector/trading/models/product_search.py
@@ -117,9 +117,9 @@ class WarrantsRequest(ProductInfo):
 
 
 class ProductBatch(BaseModel):
-    offset: int
+    #offset: int
     products: list[dict] | None = Field(default=None)
-    response_datetime: datetime = Field(default_factory=datetime.now)
+    #response_datetime: datetime = Field(default_factory=datetime.now)
     total: int = Field(default=0)
 
 


### PR DESCRIPTION
"offset" and "response_datetime" do not show anymore in the response of action_product_search